### PR TITLE
Fix for x64 build

### DIFF
--- a/windows/shellcodeexec/Makefile.v64
+++ b/windows/shellcodeexec/Makefile.v64
@@ -1,0 +1,8 @@
+shellcodeexecvc64.exe: shellcodeexec.obj __exec_payload.obj
+	link shellcodeexec.obj __exec_payload.obj
+
+shellcodeexec.obj: shellcodeexec.c
+	cl shellcodeexec.c /Os /TC /c
+
+__exec_payload.obj: __exec_payload.asm
+	ml64 __exec_payload.asm /c

--- a/windows/shellcodeexec/__exec_payload.asm
+++ b/windows/shellcodeexec/__exec_payload.asm
@@ -1,0 +1,7 @@
+.CODE
+__exec_payload PROC x:QWORD
+   mov rax, x
+   call QWORD PTR[rax]
+   ret
+__exec_payload ENDP 
+END 


### PR DESCRIPTION
This is small fix, as building x64 build would never build without .asm file which you have in other projects :)
I've included nmake makefile for building x64 version, feel free to include same in VC GUI if needed... 

You want to check "kost" branch of "shellcodeexec" as it have mingw support:
https://github.com/kost/shellcodeexec

Which means I can compile windows binaries using Linux/Mac and resulting binaries are much smaller (UPXed win32 is smaller than 4 kb):
https://github.com/kost/shellcodeexec/tree/kost/bin

Also, maybe you want to take a look at scexec which is shellcodeexec on steroids:
https://github.com/kost/scexec

it supports base64/uudecode shellcode, etc.. 
